### PR TITLE
allow specifying expire= and flags= arguments

### DIFF
--- a/README
+++ b/README
@@ -67,6 +67,10 @@ key_prefix : a string to prefix before each key's number (default 'foo')
 
 value_size : size of the value to set
 
+expire : the expiration value (default 0)
+
+flags : client flags (raw number, default 0)
+
 value : define a value by hand. Must be shortish and a string.
 
 host : define a host to connect to


### PR DESCRIPTION
prealloc should avoid any performance hit for adding these, if necessary.

haven't added to binprot yet. not going to merge until I do that. may have been sending random junk as the expiration time in binprot up until now :)

@brianwatling