### PR TITLE
TLS test patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ static:
 	gcc -g -O2 -pthread -o mc-crusher mc-crusher.c pcg-basic.c itoa_ljust.c $(LDFLAGS) -Wl,-Bstatic -levent -lm -Wl,-Bdynamic
 	gcc -g -O2 -o balloon balloon.c $(LDFLAGS) -Wl,-Bstatic -Wl,-Bdynamic
 
+tls:
+	gcc -g -O2 -pthread -DUSE_TLS=1 -o mc-crusher-tls mc-crusher.c pcg-basic.c itoa_ljust.c $(LDFLAGS) -levent -lssl -lm
+	gcc -g -O2 -o balloon balloon.c $(LDFLAGS)
+
 .PHONY: install
 
 install: mc-crusher

--- a/mc-crusher.c
+++ b/mc-crusher.c
@@ -663,6 +663,7 @@ static void ascii_write_flat_to_client(void *arg) {
         c->wbuf_pos[1] = '\n';
         c->wbuf_pos += 2;
     }
+    run_counter(c);
 }
 
 /* === READERS === */


### PR DESCRIPTION
requires OpenSSL >= 1.1.0

some stuff to do:
- make one binary isntead of two, and use separate runtime functions
instead of overloading the current ones.
- better error handling in SSL_write() ?